### PR TITLE
Support fast path reads for mmapped/borrowed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /target-*
+/extract
+/firedbg
 /.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,12 +2220,14 @@ name = "fstools_asset_server"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "blocking",
  "byteorder",
  "crossbeam-channel",
  "fstools_dvdbnd",
  "fstools_formats",
  "futures-lite",
  "memmap2",
+ "serde",
  "thiserror",
  "typed-path",
 ]
@@ -3010,9 +3012,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ unwrap_used = "warn"
 fstools_formats = { path = "crates/formats", version = "0.1.0" }
 fstools_dvdbnd = { path = "crates/dvdbnd", version = "0.1.0" }
 fstools_asset_server = { path = "crates/asset-server", version = "0.1.0" }
-memmap2 = "0.7"
+memmap2 = "0.9.4"
 rayon = "1"
+serde = "1"
 thiserror = "1"

--- a/crates/asset-server/Cargo.toml
+++ b/crates/asset-server/Cargo.toml
@@ -6,12 +6,14 @@ edition.workspace = true
 
 [dependencies]
 bevy = "0.13"
+blocking = "1"
 byteorder = "1.5.0"
 crossbeam-channel = "0.5"
 fstools_dvdbnd.workspace = true
 fstools_formats.workspace = true
 futures-lite = "2"
 memmap2.workspace = true
+serde = "1"
 thiserror.workspace = true
 typed-path = "0.8"
 

--- a/crates/asset-server/src/asset_source.rs
+++ b/crates/asset-server/src/asset_source.rs
@@ -1,12 +1,11 @@
-use std::{io, io::Read, path::PathBuf, pin::Pin, sync::Arc, task::Poll};
+use std::{io, path::PathBuf, sync::Arc};
 
 use bevy::{
     app::{App, Plugin},
     asset::io::{AssetSource, AssetSourceId},
-    prelude::{AssetApp, Deref, DerefMut},
+    prelude::AssetApp,
 };
 use fstools_dvdbnd::{ArchiveKeyProvider, DvdBnd};
-use futures_lite::AsyncRead;
 
 use crate::asset_source::{
     dvdbnd::DvdBndAssetSource,
@@ -14,6 +13,7 @@ use crate::asset_source::{
 };
 
 pub mod dvdbnd;
+pub(crate) mod fast_path;
 pub mod vfs;
 
 pub struct FsAssetSourcePlugin {
@@ -55,21 +55,5 @@ impl Plugin for FsAssetSourcePlugin {
                     Some(watcher)
                 }),
         );
-    }
-}
-
-#[derive(Deref, DerefMut)]
-struct SimpleReader<R: Read>(R);
-
-impl<R: Read> Unpin for SimpleReader<R> {}
-
-impl<R: Read> AsyncRead for SimpleReader<R> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        let reader = self.get_mut();
-        Poll::Ready(reader.read(buf))
     }
 }

--- a/crates/asset-server/src/asset_source/fast_path.rs
+++ b/crates/asset-server/src/asset_source/fast_path.rs
@@ -1,0 +1,153 @@
+use std::{
+    error::Error,
+    future::Future,
+    io,
+    io::Read,
+    pin::{pin, Pin},
+    task::Poll,
+};
+
+use bevy::{
+    app::App,
+    asset::{
+        io::{AssetSourceId, Reader},
+        meta::Settings,
+        Asset, AssetLoader, BoxedFuture, LoadContext,
+    },
+    prelude::{AssetApp, Deref, DerefMut},
+};
+use futures_lite::{AsyncRead, AsyncReadExt};
+use memmap2::Mmap;
+use serde::{Deserialize, Serialize};
+
+pub trait FastPathAppExt: AssetApp {
+    fn register_fast_path_loader<T: FastPathAssetLoader + 'static>(
+        &mut self,
+        loader: T,
+    ) -> &mut Self;
+}
+
+impl FastPathAppExt for App {
+    fn register_fast_path_loader<T: FastPathAssetLoader + 'static>(
+        &mut self,
+        loader: T,
+    ) -> &mut Self {
+        self.register_asset_loader(FastPathAssetLoaderInstance(loader))
+    }
+}
+
+pub trait FastPathAssetLoader: Send + Sync {
+    type Asset: Asset;
+
+    type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
+
+    /// The type of [error](`std::error::Error`) which could be encountered by this loader.
+    type Error: Into<Box<dyn Error + Send + Sync + 'static>> + From<io::Error>;
+
+    fn load_from_bytes<'a>(
+        reader: &'a [u8],
+        settings: &'a Self::Settings,
+        load_context: &'a mut LoadContext,
+    ) -> impl Future<Output = Result<Self::Asset, Self::Error>> + Send;
+
+    fn extensions(&self) -> &[&str] {
+        &[]
+    }
+}
+
+#[derive(Deref, DerefMut)]
+pub struct FastPathAssetLoaderInstance<T: FastPathAssetLoader>(T);
+
+impl<T: FastPathAssetLoader> From<T> for FastPathAssetLoaderInstance<T> {
+    fn from(value: T) -> Self {
+        FastPathAssetLoaderInstance(value)
+    }
+}
+
+impl<T: FastPathAssetLoader + Send + Sync + 'static> AssetLoader
+    for FastPathAssetLoaderInstance<T>
+{
+    type Asset = T::Asset;
+
+    type Settings = T::Settings;
+
+    type Error = T::Error;
+
+    fn load<'a>(
+        &'a self,
+        reader: &'a mut Reader,
+        settings: &'a Self::Settings,
+        load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+        Box::pin(async move {
+            let dvdbnd_asset_source_id: AssetSourceId = AssetSourceId::from("dvdbnd");
+            let vfs_asset_source_id: AssetSourceId = AssetSourceId::from("vfs");
+
+            let source = load_context.asset_path().source();
+            let data = if source == &dvdbnd_asset_source_id || source == &vfs_asset_source_id {
+                // SAFETY: This invariant is upheld by the `dvdbnd` and `vfs` asset source
+                // implementations. They MUST return an implementation of FastPathReader.
+                let reader = unsafe { (reader as *mut Reader).cast::<FastPathReader>().as_mut() };
+                reader.and_then(|r| r.as_bytes())
+            } else {
+                None
+            };
+
+            match data {
+                None => {
+                    let mut buffer = Vec::new();
+                    reader.read_to_end(&mut buffer).await?;
+
+                    T::load_from_bytes(&buffer, settings, load_context).await
+                }
+                Some(slice) => T::load_from_bytes(slice, settings, load_context).await,
+            }
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        T::extensions(&self.0)
+    }
+}
+
+/// An [`AsyncRead`] implementation that allows consuming Bevy asset loaders to bypass the read
+/// implementation and directly access the data when available.
+pub enum FastPathReader<'a> {
+    MemoryMapped(Mmap, usize),
+    Reader(Box<dyn AsyncRead + Unpin + Send + Sync + 'a>),
+    Slice(&'a [u8]),
+}
+
+impl<'a> FastPathReader<'a> {
+    pub fn as_bytes(&'a self) -> Option<&'a [u8]> {
+        match self {
+            FastPathReader::Slice(slice) => Some(slice),
+            FastPathReader::MemoryMapped(mmap, _) => Some(&mmap[..]),
+            FastPathReader::Reader(_) => None,
+        }
+    }
+}
+
+impl<'a> AsyncRead for FastPathReader<'a> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            FastPathReader::Reader(reader) => AsyncRead::poll_read(pin!(reader), _cx, buf),
+            FastPathReader::Slice(slice) => Poll::Ready(Read::read(slice, buf)),
+            FastPathReader::MemoryMapped(dvd_bnd, ref mut offset) => {
+                let mut data = &dvd_bnd[*offset..];
+                let read = match Read::read(&mut data, buf) {
+                    Ok(length) => length,
+                    Err(e) => return Poll::Ready(Err(e)),
+                };
+
+                *offset += read;
+
+                Poll::Ready(Ok(read))
+            }
+        }
+    }
+}

--- a/crates/asset-server/src/asset_source/vfs.rs
+++ b/crates/asset-server/src/asset_source/vfs.rs
@@ -16,7 +16,7 @@ use crossbeam_channel::Sender;
 use memmap2::{Mmap, MmapOptions};
 use typed_path::Utf8WindowsPathBuf;
 
-use crate::asset_source::SimpleReader;
+use crate::asset_source::fast_path::FastPathReader;
 
 pub mod watcher;
 
@@ -98,7 +98,7 @@ impl AssetReader for VfsAssetSource {
             let bytes = self.entry_bytes(path.to_str().expect("invalid path"));
 
             match bytes {
-                Some(data) => Ok(Box::new(SimpleReader(data)) as Box<Reader>),
+                Some(data) => Ok(Box::new(FastPathReader::Slice(data)) as Box<Reader>),
                 None => Err(AssetReaderError::NotFound(path.to_path_buf())),
             }
         })

--- a/crates/asset-server/src/types.rs
+++ b/crates/asset-server/src/types.rs
@@ -1,9 +1,13 @@
 use bevy::prelude::*;
 
-use crate::types::{
-    bnd4::{Archive, ArchiveEntry, Bnd4Loader},
-    flver::{FlverAsset, FlverLoader},
-    msb::{MsbAsset, MsbAssetLoader, MsbPartAsset, MsbPointAsset},
+use self::{flver::FlverAssetLoader, msb::MsbAssetLoader};
+use crate::{
+    asset_source::fast_path::FastPathAppExt,
+    types::{
+        bnd4::{Archive, ArchiveEntry, Bnd4Loader},
+        flver::FlverAsset,
+        msb::MsbAsset,
+    },
 };
 
 pub mod bnd4;
@@ -20,12 +24,8 @@ impl Plugin for FsFormatsPlugin {
             .init_asset::<Archive>()
             .init_asset::<ArchiveEntry>()
             .init_asset::<MsbAsset>()
-            .register_asset_loader(MsbAssetLoader)
-            .register_asset_loader(FlverLoader)
+            .register_fast_path_loader(MsbAssetLoader)
+            .register_fast_path_loader(FlverAssetLoader)
             .register_asset_loader(Bnd4Loader);
-        app.init_asset::<MsbAsset>()
-            .init_asset::<MsbPointAsset>()
-            .init_asset::<MsbPartAsset>()
-            .init_asset_loader::<MsbAssetLoader>();
     }
 }

--- a/crates/asset-server/src/types/msb.rs
+++ b/crates/asset-server/src/types/msb.rs
@@ -1,12 +1,8 @@
-use bevy::{
-    asset::{io::Reader, Asset, AssetLoader, AsyncReadExt, LoadContext},
-    prelude::*,
-    utils::BoxedFuture,
-};
+use bevy::{asset::LoadContext, prelude::*};
 use fstools_formats::msb::{parts::PartData, Msb, MsbError};
 use thiserror::Error;
 
-use crate::types::flver::FlverAsset;
+use crate::{asset_source::fast_path::FastPathAssetLoader, types::flver::FlverAsset};
 
 #[derive(Asset, TypePath, Debug)]
 pub struct MsbAsset {
@@ -72,108 +68,97 @@ impl MsbAssetLoader {
     }
 }
 
-impl AssetLoader for MsbAssetLoader {
+impl FastPathAssetLoader for MsbAssetLoader {
     type Asset = MsbAsset;
     type Settings = ();
     type Error = MsbAssetLoaderError;
 
-    fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader,
-        _settings: &'a (),
-        load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
-        Box::pin(async move {
-            let mut buffer = Vec::new();
-            reader.read_to_end(&mut buffer).await?;
+    async fn load_from_bytes<'a>(
+        reader: &'a [u8],
+        _settings: &'a Self::Settings,
+        load_context: &'a mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let msb = Msb::parse(reader)?;
 
-            // Account for DCX compression
-            let msb = Msb::parse(&buffer)?;
+        let models = msb
+            .models()
+            .expect("Could not get model set from MSB")
+            .map(|m| {
+                let mut name = m
+                    .expect("Could not get name bytes from model entry")
+                    .name
+                    .to_string_lossy();
+                if name.starts_with('m') {
+                    let msb_name = load_context.asset_path().to_string();
+                    name = format!(
+                        "{}_{}",
+                        &msb_name[21..33], // Lets fucking pray
+                        &name[1..],
+                    );
+                }
 
-            let models = msb
-                .models()
-                .expect("Could not get model set from MSB")
-                .map(|m| {
-                    let mut name = m
-                        .expect("Could not get name bytes from model entry")
-                        .name
-                        .to_string_lossy();
-                    if name.starts_with('m') {
-                        let msb_name = load_context.asset_path().to_string();
-                        name = format!(
-                            "{}_{}",
-                            &msb_name[21..33], // Lets fucking pray
-                            &name[1..],
-                        );
+                let model_name = format!("vfs://{}.flver", name);
+
+                load_context.load(model_name)
+            })
+            .collect::<Vec<Handle<FlverAsset>>>();
+
+        Ok(MsbAsset {
+            points: msb
+                .points()
+                .expect("Could not get point set from MSB")
+                .map(|p| {
+                    let point = p.as_ref().expect("Could not get point entry from MSB");
+                    load_context.labeled_asset_scope(point.name.to_string_lossy(), |_| {
+                        MsbPointAsset {
+                            name: point.name.to_string_lossy(),
+                            position: Vec3::new(
+                                point.position[0].get(),
+                                point.position[1].get(),
+                                point.position[2].get(),
+                            ),
+                        }
+                    })
+                })
+                .collect(),
+
+            parts: msb
+                .parts()
+                .expect("Could not get parts set from MSB")
+                .filter_map(|p| {
+                    let part = p.as_ref().expect("Could not get point entry from MSB");
+
+                    if let PartData::DummyAsset(_) = part.part {
+                        return None;
                     }
 
-                    let model_name = format!("vfs://{}.flver", name);
-
-                    load_context.load(model_name)
-                })
-                .collect::<Vec<Handle<FlverAsset>>>();
-
-            Ok(MsbAsset {
-                points: msb
-                    .points()
-                    .expect("Could not get point set from MSB")
-                    .map(|p| {
-                        let point = p.as_ref().expect("Could not get point entry from MSB");
-                        load_context.labeled_asset_scope(point.name.to_string_lossy(), |_| {
-                            MsbPointAsset {
-                                name: point.name.to_string_lossy(),
-                                position: Vec3::new(
-                                    point.position[0].get(),
-                                    point.position[1].get(),
-                                    point.position[2].get(),
-                                ),
-                            }
-                        })
-                    })
-                    .collect(),
-
-                parts: msb
-                    .parts()
-                    .expect("Could not get parts set from MSB")
-                    .filter_map(|p| {
-                        let part = p.as_ref().expect("Could not get point entry from MSB");
-
-                        if let PartData::DummyAsset(_) = part.part {
-                            return None;
-                        }
-
-                        Some(
-                            load_context.labeled_asset_scope(part.name.to_string_lossy(), |_| {
-                                MsbPartAsset {
-                                    name: part.name.to_string_lossy(),
-                                    transform: Self::make_msb_transform(
-                                        Vec3::new(
-                                            part.position[0].get(),
-                                            part.position[1].get(),
-                                            part.position[2].get(),
-                                        ),
-                                        Some(Vec3::new(
-                                            part.rotation[0].get(),
-                                            part.rotation[1].get(),
-                                            part.rotation[2].get(),
-                                        )),
-                                        Some(Vec3::new(
-                                            part.scale[0].get(),
-                                            part.scale[1].get(),
-                                            part.scale[2].get(),
-                                        )),
+                    Some(
+                        load_context.labeled_asset_scope(part.name.to_string_lossy(), |_| {
+                            MsbPartAsset {
+                                name: part.name.to_string_lossy(),
+                                transform: MsbAssetLoader::make_msb_transform(
+                                    Vec3::new(
+                                        part.position[0].get(),
+                                        part.position[1].get(),
+                                        part.position[2].get(),
                                     ),
-                                    model: models[part.model_index.get() as usize].clone(),
-                                }
-                            }),
-                        )
-                    })
-                    .collect(),
-            })
+                                    Some(Vec3::new(
+                                        part.rotation[0].get(),
+                                        part.rotation[1].get(),
+                                        part.rotation[2].get(),
+                                    )),
+                                    Some(Vec3::new(
+                                        part.scale[0].get(),
+                                        part.scale[1].get(),
+                                        part.scale[2].get(),
+                                    )),
+                                ),
+                                model: models[part.model_index.get() as usize].clone(),
+                            }
+                        }),
+                    )
+                })
+                .collect(),
         })
-    }
-
-    fn extensions(&self) -> &[&str] {
-        &["msb", "msb.dcx"]
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fstools_config"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+directories = "5"
+serde = {  version = "1"}
+serde_derive = "1"
+toml = "0.8"
+
+[lints]
+workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,0 +1,79 @@
+use std::{
+    env,
+    error::Error,
+    fs,
+    fs::File,
+    io,
+    path::PathBuf,
+    str::FromStr,
+    sync::{Arc, RwLock},
+};
+
+use directories::ProjectDirs;
+use serde_derive::{Deserialize, Serialize};
+use toml::{Table, Value};
+
+use crate::paths::Paths;
+
+mod paths;
+
+#[derive(Default, Deserialize, Serialize)]
+struct Options {
+    paths: Paths,
+}
+
+thread_local! {
+    static CURRENT_CONFIG: RwLock<Arc<Options>> = RwLock::new(Default::default());
+}
+
+fn env_override_str<T: FromStr>(value: &mut Option<T>, env_name: &str) {
+    if let Some(env_var) = env::var(env_name)
+        .ok()
+        .and_then(|env_var| T::from_str(&env_var).ok())
+    {
+        *value = Some(env_var);
+    }
+}
+
+impl Options {
+    pub fn path() -> Option<PathBuf> {
+        const SETTINGS_FILENAME: &str = "settings.toml";
+
+        let dirs = ProjectDirs::from("io.github", "soulsmods", "fstools")?;
+        let config_dir = dirs.config_dir();
+
+        Some(config_dir.join("settings.toml"))
+    }
+
+    pub fn save(&self) -> Result<(), io::Error> {
+        let config_path =
+            Self::path().ok_or(io::Error::other("Couldn't determine config directory"))?;
+
+        let output = toml::to_string_pretty(self).map_err(io::Error::other)?;
+        fs::write(config_path, output)?;
+
+        Ok(())
+    }
+
+    pub fn load() -> Result<Self, io::Error> {
+        let config_path =
+            Self::path().ok_or(io::Error::other("Couldn't determine config directory"))?;
+
+        let mut options = fs::read_to_string(config_path)
+            .and_then(|contents| toml::from_str::<Options>(&contents).map_err(io::Error::other))
+            .unwrap_or_default();
+
+        env_override_str(&mut options.paths.elden_ring, "ER_PATH");
+        env_override_str(&mut options.paths.elden_ring_keys, "ER_KEYS_PATH");
+
+        Ok(options)
+    }
+
+    pub fn current() -> Arc<Options> {
+        CURRENT_CONFIG.with(|c| c.read().expect("config_r_lock").clone())
+    }
+
+    pub fn make_current(self) {
+        CURRENT_CONFIG.with(|c| *c.write().expect("config_w_lock") = Arc::new(self));
+    }
+}

--- a/crates/config/src/paths.rs
+++ b/crates/config/src/paths.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct Paths {
+    pub elden_ring: Option<PathBuf>,
+    pub elden_ring_keys: Option<PathBuf>,
+}

--- a/crates/dvdbnd/src/lib.rs
+++ b/crates/dvdbnd/src/lib.rs
@@ -142,7 +142,7 @@ impl DvdBnd {
 
                 let _ = mmap.advise(Advice::Sequential);
 
-                Ok(DvdBndEntryReader::new(mmap))
+                Ok(DvdBndEntryReader::new(mmap.make_read_only()?))
             }
             None => Err(DvdBndEntryError::NotFound),
         }

--- a/crates/dvdbnd/src/reader.rs
+++ b/crates/dvdbnd/src/reader.rs
@@ -1,19 +1,25 @@
 use std::io::{Error, Read, Seek, SeekFrom};
 
-use memmap2::MmapMut;
+use memmap2::Mmap;
 
 pub struct DvdBndEntryReader {
-    mmap: MmapMut,
+    mmap: Mmap,
     position: usize,
 }
 
 impl DvdBndEntryReader {
-    pub fn new(mmap: MmapMut) -> Self {
+    pub fn new(mmap: Mmap) -> Self {
         Self { mmap, position: 0 }
     }
 
     pub fn data(&self) -> &[u8] {
         &self.mmap[..]
+    }
+}
+
+impl From<DvdBndEntryReader> for Mmap {
+    fn from(value: DvdBndEntryReader) -> Self {
+        value.mmap
     }
 }
 

--- a/tests/dcx.rs
+++ b/tests/dcx.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, error::Error, io::Read, path::PathBuf, sync::Arc};
+use std::{collections::HashSet, error::Error, path::PathBuf, sync::Arc};
 
 use fstools::{formats::dcx::DcxHeader, prelude::*};
 use fstools_formats::dcx::DcxError;
@@ -54,17 +54,7 @@ pub fn check_file(vfs: Arc<DvdBnd>, file: &str) -> Result<(), Failed> {
         Err(_) => return Err("failed to parse DCX header".into()),
     };
 
-    let mut buffer = [0u8; 4096 * 4];
-
-    loop {
-        match reader.read(&mut buffer) {
-            Ok(0) => break, // End of file
-            Ok(_) => {}
-            Err(e) => {
-                return Err(e.into());
-            }
-        }
-    }
+    std::io::copy(&mut reader, &mut std::io::sink())?;
 
     Ok(())
 }


### PR DESCRIPTION
Often times an AssetLoader receives a AsyncRead implementation that is backed by a memory map or a byte slice. In cases where we're dealing with a format that has a zero-copy parser this introduces an unnecessary copy. We avoid this by special casing the "vfs" and "dvdbnd" asset sources to produce a special `FastPathAssetReader`.