### PR TITLE
Auto-discovery of Oodle binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block-sys"
 version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1747,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2003,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "block-buffer",
  "const-oid",
  "crypto-common",
 ]
@@ -1988,6 +2013,15 @@ name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
@@ -2328,6 +2362,7 @@ dependencies = [
  "fstools_dvdbnd",
  "fstools_elden_ring_support",
  "fstools_formats",
+ "fstools_oodle_rt",
  "insta",
  "libtest-mimic",
 ]
@@ -2409,6 +2444,8 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "libloading 0.8.3",
+ "steamlocate",
+ "walkdir",
 ]
 
 [[package]]
@@ -2959,6 +2996,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyvalues-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4c8354918309196302015ac9cae43362f1a13d0d5c5539a33b4c2fd2cd6d25"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "thiserror",
+]
+
+[[package]]
+name = "keyvalues-serde"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0447866c47c00f8bd1949618e8f63017cf93e985b4684dc28d784527e2882390"
+dependencies = [
+ "keyvalues-parser",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -3676,6 +3735,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4181,6 +4285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4398,20 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "steamlocate"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b6a4810c4e7fecb0123a9a8ba99b335c17d92e636c265ef99108ee4734c812"
+dependencies = [
+ "crc",
+ "dirs",
+ "keyvalues-parser",
+ "keyvalues-serde",
+ "serde",
+ "winreg",
+]
 
 [[package]]
 name = "strsim"
@@ -4571,6 +4700,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -5272,6 +5407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 fstools_formats.workspace = true
 fstools_dvdbnd.workspace = true
+fstools_oodle_rt.workspace = true
 
 [dev-dependencies]
 criterion = "0.5"
@@ -60,4 +61,5 @@ fstools_oodle_rt = { path = "crates/oodle-rt", version = "0.1.0" }
 memmap2 = "0.9.4"
 rayon = "1"
 serde = "1"
+steamlocate = "=2.0.0-beta.2"
 thiserror = "1"

--- a/crates/dvdbnd/src/lib.rs
+++ b/crates/dvdbnd/src/lib.rs
@@ -5,7 +5,7 @@ use aes::{
     Aes128,
 };
 use fstools_formats::bhd::Bhd;
-use memmap2::{Advice, MmapOptions};
+use memmap2::MmapOptions;
 use rayon::{iter::ParallelBridge, prelude::ParallelIterator};
 use thiserror::Error;
 
@@ -151,7 +151,8 @@ impl DvdBnd {
                         data_cipher.decrypt_blocks(blocks);
                     });
 
-                let _ = mmap.advise(Advice::Sequential);
+                #[cfg(unix)]
+                let _ = mmap.advise(memmap2::Advice::Sequential);
 
                 Ok(DvdBndEntryReader::new(mmap.make_read_only()?))
             }

--- a/crates/formats/src/dcx/oodle.rs
+++ b/crates/formats/src/dcx/oodle.rs
@@ -27,12 +27,13 @@ pub struct OodleReader<R: Read> {
     /// The number of bytes that the consuming reader is lagging behind the decoder.
     decode_buffer_reader_lag: usize,
 
-    /// Oodle requires at least [OODLELZ_BLOCK_LEN] bytes available in the input buffer, which the
-    /// read buffer might not fit. Instead, we buffer to this intermediate buffer and treat it as a
-    /// sliding window to ensure there are always OODLELZ_BLOCK_LEN bytes available to read.
+    /// Oodle requires at least [`OODLELZ_BLOCK_LEN`] bytes available in the input buffer, which
+    /// the read buffer might not fit. Instead, we buffer to this intermediate buffer and treat
+    /// it as a sliding window to ensure there are always `OODLELZ_BLOCK_LEN` bytes available
+    /// to read.
     io_buffer: Box<[u8]>,
 
-    /// The number of bytes available to read from [io_buffer], ending at [io_buffer_pos].
+    /// The number of bytes available to read from [`io_buffer`], ending at [`io_buffer_pos`].
     io_buffer_writer_pos: usize,
 
     /// Current position within the IO buffer.

--- a/crates/formats/src/matbin/mod.rs
+++ b/crates/formats/src/matbin/mod.rs
@@ -251,7 +251,7 @@ pub struct Parameter {
     /// Adler32 hash of the name string without the string terminator
     name_hash: U32<LE>,
 
-    /// Type of the value pointed at by value_offset
+    /// Type of the value pointed at by `value_offset`
     value_type: U32<LE>,
 
     _padding18: Padding<16>,

--- a/crates/oodle-rt/Cargo.toml
+++ b/crates/oodle-rt/Cargo.toml
@@ -8,6 +8,8 @@ edition.workspace = true
 
 [dependencies]
 libloading = "0.8.3"
+steamlocate.workspace = true
+walkdir = "2"
 
 [build-dependencies.bindgen]
 version = "0.69"


### PR DESCRIPTION
Searches the directory the current binary was launched from as well as Steam app paths that are listed in an allow list for Oodle shared libraries on first load if none was provided.