### PR TITLE
Remove padding bytes from DvdBnd entry reader output

### DIFF
--- a/crates/dvdbnd/src/lib.rs
+++ b/crates/dvdbnd/src/lib.rs
@@ -154,7 +154,10 @@ impl DvdBnd {
                 #[cfg(unix)]
                 let _ = mmap.advise(memmap2::Advice::Sequential);
 
-                Ok(DvdBndEntryReader::new(mmap.make_read_only()?))
+                Ok(DvdBndEntryReader::new(
+                    mmap.make_read_only()?,
+                    entry.file_size as usize,
+                ))
             }
             None => Err(DvdBndEntryError::NotFound),
         }

--- a/crates/dvdbnd/src/lib.rs
+++ b/crates/dvdbnd/src/lib.rs
@@ -154,9 +154,16 @@ impl DvdBnd {
                 #[cfg(unix)]
                 let _ = mmap.advise(memmap2::Advice::Sequential);
 
+                // DCXes dont have an unpadded size set
+                let effective_file_size = if entry.file_size != 0 {
+                    entry.file_size
+                } else {
+                    entry.file_size_with_padding
+                } as usize;
+
                 Ok(DvdBndEntryReader::new(
                     mmap.make_read_only()?,
-                    entry.file_size as usize,
+                    effective_file_size,
                 ))
             }
             None => Err(DvdBndEntryError::NotFound),


### PR DESCRIPTION
Should be straight forward, there's still the question around the Mmap conversion though.