### PR TITLE
Feature: ZSTD support for DCX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /extract
 /firedbg
 /.idea
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,6 +2436,7 @@ dependencies = [
  "thiserror",
  "widestring",
  "zerocopy",
+ "zstd",
 ]
 
 [[package]]
@@ -5476,3 +5477,31 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block-sys"
 version = "0.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1391,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -2417,6 +2435,8 @@ dependencies = [
 name = "fstools_elden_ring_support"
 version = "0.1.0"
 dependencies = [
+ "aes",
+ "cbc",
  "fstools",
 ]
 
@@ -2883,6 +2903,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 

--- a/crates/formats/Cargo.toml
+++ b/crates/formats/Cargo.toml
@@ -23,6 +23,7 @@ rsa = "0.9"
 thiserror.workspace = true
 widestring = "1"
 zerocopy = { version = "0.7.32", features = ["derive"] }
+zstd = "0.13"
 
 [lints]
 workspace = true

--- a/crates/formats/src/dcx/oodle.rs
+++ b/crates/formats/src/dcx/oodle.rs
@@ -6,10 +6,10 @@ use std::{
 use fstools_oodle_rt::{decoder::OodleDecoder, Compressor, Oodle, OODLELZ_BLOCK_LEN};
 
 // SAFETY: `OodleLZDecoder` pointer is safe to use across several threads.
-unsafe impl<R: Read> Sync for OodleReader<R> {}
+unsafe impl<R: Read + Sync> Sync for OodleReader<R> {}
 
 // SAFETY: See above.
-unsafe impl<R: Read> Send for OodleReader<R> {}
+unsafe impl<R: Read + Send> Send for OodleReader<R> {}
 
 pub struct OodleReader<R: Read> {
     reader: R,

--- a/crates/formats/src/dcx/zstd.rs
+++ b/crates/formats/src/dcx/zstd.rs
@@ -1,0 +1,16 @@
+use std::io::{self, Read};
+
+/// Trivial wrapper around a [`zstd::Decoder<BufReader<R>>`].
+pub struct ZstdDecoder<R: Read>(zstd::Decoder<'static, io::BufReader<R>>);
+
+impl<R: Read> ZstdDecoder<R> {
+    pub fn new(reader: R) -> io::Result<Self> {
+        Ok(Self(zstd::Decoder::new(reader)?))
+    }
+}
+
+impl<R: Read> Read for ZstdDecoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}

--- a/crates/support/elden_ring/Cargo.toml
+++ b/crates/support/elden_ring/Cargo.toml
@@ -8,3 +8,5 @@ authors.workspace = true
 
 [dependencies]
 fstools.workspace = true
+aes = "0.8"
+cbc = "0.1"

--- a/crates/support/elden_ring/src/lib.rs
+++ b/crates/support/elden_ring/src/lib.rs
@@ -31,7 +31,7 @@ pub fn dictionary() -> impl Iterator<Item = PathBuf> {
         .map(std::path::PathBuf::from)
 }
 
-pub fn decyrpt_regulation(reader: &mut impl Read) -> io::Result<Vec<u8>> {
+pub fn decrypt_regulation(reader: &mut impl Read) -> io::Result<Vec<u8>> {
     const REGULATION_KEY: &'static [u8; 32] = &[
         0x99, 0xBF, 0xFC, 0x36, 0x6A, 0x6B, 0xC8, 0xC6, 0xF5, 0x82, 0x7D, 0x09, 0x36, 0x02, 0xD6,
         0x76, 0xC4, 0x28, 0x92, 0xA0, 0x1C, 0x20, 0x7F, 0xB0, 0x24, 0xD3, 0xAF, 0x4E, 0x49, 0x3F,
@@ -57,7 +57,7 @@ pub fn decyrpt_regulation(reader: &mut impl Read) -> io::Result<Vec<u8>> {
 
 pub fn load_regulation(game_path: impl AsRef<Path>) -> io::Result<BND4> {
     let regulation_bytes = std::fs::read(game_path.as_ref().join("regulation.bin"))?;
-    let dcx_bytes = decyrpt_regulation(&mut regulation_bytes.as_slice())?;
+    let dcx_bytes = decrypt_regulation(&mut regulation_bytes.as_slice())?;
 
     let (_, mut dcx_decoder) = DcxHeader::read(io::Cursor::new(dcx_bytes))
         .map_err(|_| io::Error::other("DCX header reading failed"))?;

--- a/crates/support/elden_ring/src/lib.rs
+++ b/crates/support/elden_ring/src/lib.rs
@@ -1,6 +1,13 @@
-use std::{io, path::PathBuf};
+use std::{
+    io::{self, Read},
+    path::{Path, PathBuf},
+};
 
-use fstools::dvdbnd::{ArchiveKeyProvider, DvdBnd};
+use aes::cipher::{BlockDecryptMut, KeyIvInit};
+use fstools::{
+    dvdbnd::{ArchiveKeyProvider, DvdBnd},
+    formats::{bnd4::BND4, dcx::DcxHeader},
+};
 
 pub fn load_dvd_bnd(
     game_path: PathBuf,
@@ -22,4 +29,42 @@ pub fn dictionary() -> impl Iterator<Item = PathBuf> {
         .lines()
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
         .map(std::path::PathBuf::from)
+}
+
+pub fn decyrpt_regulation(reader: &mut impl Read) -> io::Result<Vec<u8>> {
+    const REGULATION_KEY: &'static [u8; 32] = &[
+        0x99, 0xBF, 0xFC, 0x36, 0x6A, 0x6B, 0xC8, 0xC6, 0xF5, 0x82, 0x7D, 0x09, 0x36, 0x02, 0xD6,
+        0x76, 0xC4, 0x28, 0x92, 0xA0, 0x1C, 0x20, 0x7F, 0xB0, 0x24, 0xD3, 0xAF, 0x4E, 0x49, 0x3F,
+        0xEF, 0x99,
+    ];
+
+    let mut iv = [0u8; 16];
+    reader.read_exact(&mut iv)?;
+
+    let mut out_buf = Vec::new();
+    reader.read_to_end(&mut out_buf)?;
+
+    type Aes256Cbc = cbc::Decryptor<aes::Aes256>;
+    let mut cipher = Aes256Cbc::new_from_slices(REGULATION_KEY, &iv).unwrap();
+
+    // SAFETY: GenericArray<u8, _> is safe to transmute from an equiv. slice of u8s
+    unsafe {
+        cipher.decrypt_blocks_mut(out_buf.align_to_mut().1);
+    }
+
+    Ok(out_buf)
+}
+
+pub fn load_regulation(game_path: impl AsRef<Path>) -> io::Result<BND4> {
+    let regulation_bytes = std::fs::read(game_path.as_ref().join("regulation.bin"))?;
+    let dcx_bytes = decyrpt_regulation(&mut regulation_bytes.as_slice())?;
+
+    let (_, mut dcx_decoder) = DcxHeader::read(io::Cursor::new(dcx_bytes))
+        .map_err(|_| io::Error::other("DCX header reading failed"))?;
+
+    let mut bnd4_bytes = Vec::new();
+    dcx_decoder.read_to_end(&mut bnd4_bytes)?;
+
+    BND4::from_reader(io::Cursor::new(bnd4_bytes))
+        .map_err(|_| io::Error::other("Failed to read regulation BND4"))
 }

--- a/tests/dcx.rs
+++ b/tests/dcx.rs
@@ -2,12 +2,13 @@ use std::{
     collections::HashSet,
     error::Error,
     ffi::OsStr,
+    io::{self, Read},
     path::{Path, PathBuf},
     sync::Arc,
 };
 
 use fstools::{formats::dcx::DcxHeader, prelude::*};
-use fstools_elden_ring_support::dictionary;
+use fstools_elden_ring_support::{decyrpt_regulation, dictionary};
 use fstools_formats::dcx::DcxError;
 use insta::assert_snapshot;
 use libtest_mimic::{Arguments, Failed, Trial};
@@ -15,6 +16,7 @@ use libtest_mimic::{Arguments, Failed, Trial};
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Arguments::from_args();
     let er_path = PathBuf::from(std::env::var("ER_PATH").expect("er_path"));
+    let reg_path = er_path.join("regulation.bin");
     let keys_path = PathBuf::from(std::env::var("ER_KEYS_PATH").expect("er_keys_path"));
     let vfs = Arc::new(fstools_elden_ring_support::load_dvd_bnd(
         er_path,
@@ -39,7 +41,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         tests.push(test);
     }
 
+    // Test against the regulation DCX (ZSTD encoded since 1.12)
+    tests.push(Trial::test("regulation.bin", move || {
+        check_regulation(&reg_path)
+    }));
+
     libtest_mimic::run(&args, tests).exit();
+}
+
+pub fn check_regulation(path: &Path) -> Result<(), Failed> {
+    let regulation_bytes = std::fs::read(path.join("regulation.bin"))?;
+    let dcx_bytes = decyrpt_regulation(&mut regulation_bytes.as_slice())?;
+    check_dcx(io::Cursor::new(dcx_bytes))
 }
 
 pub fn check_file(vfs: Arc<DvdBnd>, file: &Path) -> Result<(), Failed> {
@@ -49,14 +62,17 @@ pub fn check_file(vfs: Arc<DvdBnd>, file: &Path) -> Result<(), Failed> {
             return Ok(());
         }
     };
+    check_dcx(file)
+}
 
-    let (_, mut reader) = match DcxHeader::read(file) {
+pub fn check_dcx(reader: impl Read) -> Result<(), Failed> {
+    let (_, mut decoder) = match DcxHeader::read(reader) {
         Ok(details) => details,
         Err(DcxError::UnknownAlgorithm(_)) => return Ok(()),
         Err(_) => return Err("failed to parse DCX header".into()),
     };
 
-    std::io::copy(&mut reader, &mut std::io::sink())?;
+    std::io::copy(&mut decoder, &mut std::io::sink())?;
 
     Ok(())
 }

--- a/tests/dcx.rs
+++ b/tests/dcx.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use fstools::{formats::dcx::DcxHeader, prelude::*};
-use fstools_elden_ring_support::{decyrpt_regulation, dictionary};
+use fstools_elden_ring_support::{decrypt_regulation, dictionary};
 use fstools_formats::dcx::DcxError;
 use insta::assert_snapshot;
 use libtest_mimic::{Arguments, Failed, Trial};
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 pub fn check_regulation(path: &Path) -> Result<(), Failed> {
     let regulation_bytes = std::fs::read(path.join("regulation.bin"))?;
-    let dcx_bytes = decyrpt_regulation(&mut regulation_bytes.as_slice())?;
+    let dcx_bytes = decrypt_regulation(&mut regulation_bytes.as_slice())?;
     check_dcx(io::Cursor::new(dcx_bytes))
 }
 


### PR DESCRIPTION
- Adds ZSTD streaming decompression support to DCX via `zstd::Decoder<'static, BufReader<R>>`
- Adds code in `support/elden_ring` to decrypt and load the regulation parambnd
- Adds DCX test using the decrypted ER regulation (which is ZSTD compressed since 1.12)
- Fixes unsound `Sync/Send` implementation of `OodleReader`